### PR TITLE
add native support for ember tests

### DIFF
--- a/ember.js
+++ b/ember.js
@@ -5,8 +5,7 @@ module.exports = {
   },
   globals: {
     server: true, // mirage
-    withFeature: true, // feature flag
-    withoutFeature: true
+    withFeature: true // feature flag
   },
   extends: ["eslint:recommended", "plugin:ember-suave/recommended", "./core.js"]
 };

--- a/ember.js
+++ b/ember.js
@@ -1,6 +1,12 @@
 module.exports = {
   env: {
-    browser: true
+    browser: true,
+    embertest: true
   },
-  extends: ['eslint:recommended', 'plugin:ember-suave/recommended', './core.js']
+  globals: {
+    server: true, // mirage
+    withFeature: true, // feature flag
+    withoutFeature: true
+  },
+  extends: ["eslint:recommended", "plugin:ember-suave/recommended", "./core.js"]
 };


### PR DESCRIPTION
**next:** create a new release

Introduce support for `ember` tests by default in the `peopledoc/ember` config

### How to migrate?

1. Update to 

       npm install --save-dev peopledoc/eslint-config-peopledoc#1.1.0
2. Remove your `./tests/.eslintrc.js`

Check [`embertest` globals](https://github.com/sindresorhus/globals/blob/master/globals.json#L1371)