### PR TITLE
Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Preset configurations are available for:
 
     extends: ['peopledoc/es5']
 
+### Formatting Code
+
+We use prettier-eslint in order to format it with `prettier` ([why?](https://prettier.io/docs/en/why-prettier.html)) then fix issue with `eslint --fix`:
+
+    ./node_modules/.bin/prettier-eslint --list-different --single-quote {app,config,mirage,lib,server,tests}/{**/,}*.js
+
+Once you have review change you can write them with
+
+    ./node_modules/.bin/prettier-eslint --write --single-quote {app,config,mirage,lib,server,tests}/{**/,}*.js
+
+:bulb: We recomment to add a custom `format` script to your _package.json_ so you can run `npm format`
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "dependencies": {
     "eslint": "4.x.x",
     "eslint-plugin-ember-suave": "1.x.x",
-    "eslint-plugin-es5": "1.x.x"
+    "eslint-plugin-es5": "1.x.x",
+    "eslint-plugin-prettier": "2.x.x",
+    "prettier": "1.x.x"
   },
   "files": [
     "core.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "eslint-plugin-ember-suave": "1.x.x",
     "eslint-plugin-es5": "1.x.x",
     "eslint-plugin-prettier": "2.x.x",
-    "prettier": "1.x.x"
+    "prettier": "1.x.x",
+    "prettier-eslint-cli": "4.x.x"
   },
   "files": [
     "core.js",

--- a/prettier.js
+++ b/prettier.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  extends: ['./base.js'],
+  plugins: ['prettier']
+};


### PR DESCRIPTION
We use prettier-eslint in order to format it with `prettier` ([why?](https://prettier.io/docs/en/why-prettier.html)) then fix issue with `eslint --fix`:

    ./node_modules/.bin/prettier-eslint --list-different --single-quote {app,mirage,tests}/{**/,}*.js

Once you have review change you can write them with

    ./node_modules/.bin/prettier-eslint --write --single-quote {app,mirage,tests}/{**/,}*.js

:bulb: We recomment to add a custom `format` script to your _package.json_ so you can run `npm format`
