### PR TITLE
feat: semi error never

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.hbs]
+insert_final_newline = false
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Once you have review change you can write them with
 
     ./node_modules/.bin/prettier-eslint --write --single-quote {app,config,mirage,lib,server,tests}/{**/,}*.js
 
-:bulb: We recomment to add a custom `format` script to your _package.json_ so you can run `npm format`
+:bulb: We recomment to add a custom `format` script to your
+_package.json_ so you can run `npm format`
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/core.js
+++ b/core.js
@@ -10,6 +10,7 @@ module.exports = {
   rules: {
     // ES6
     'arrow-parens': ['error', 'always'],
+    'eol-last': ['error', 'always'],
     'generator-star-spacing': ['error', { before: false, after: true }],
     'no-var': 'error',
     'no-useless-rename': 'error',
@@ -17,6 +18,6 @@ module.exports = {
     'prefer-destructuring': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'error',
-    'eol-last': ['error', 'always']
+    semi: ['error', 'never']
   }
 };


### PR DESCRIPTION
Closes https://github.com/peopledoc/eslint-config-peopledoc/issues/15

In this PR:

- new rule to remove the semicolons `;` enforcement; following https://github.com/peopledoc/eslint-config-peopledoc/issues/15.
- `.editorconfig` file added, copied from `ember-data-peopledoc`

Tested on a peopledoc project, and it seems to work without issue.

Further readings on semi or not:
- https://eslint.org/docs/rules/semi#require-or-disallow-semicolons-instead-of-asi-semi
- http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding
- http://inimino.org/~inimino/blog/javascript_semicolons

# How to implement?

- current version is `1.3.0`, how big of a change is it? `1.4.0` or `1.3.1` maybe?

To make the transition from semi, to no-semi, this script can be be helpful.

Add it to the script section of your projects package.json, and update this module to the version that will be released:


```
// package.json
{
[...]
  "scripts": {
    "prettier": "./node_modules/.bin/prettier-eslint --write --single-quote {app,config,mirage,lib,server,tests}/{**/,}*.js"
  }
[...]
  {
    devDependencies: {
      "eslint-config-peopledoc": "github:peopledoc/eslint-config-peopledoc#v1.4.0",
    }
  }
[...]
}
```

And then run `npm run prettier`, to clean all semicolons from your javascript files.