### PR TITLE
Rule `node/no-unpublished-import` should not be enabled for private packages

### DIFF
--- a/core.js
+++ b/core.js
@@ -4,7 +4,7 @@ module.exports = {
     es6: true
   },
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     sourceType: "module"
   },
   rules: {

--- a/ember.js
+++ b/ember.js
@@ -8,7 +8,7 @@ module.exports = {
     withFeature: true // feature flag
   },
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     sourceType: "module"
   },
   plugins: ["ember"],
@@ -29,9 +29,9 @@ module.exports = {
         "testem.js",
         "blueprints/*/index.js",
         "config/**/*.js",
-        "tests/dummy/config/**/*.js",
         "lib/*/index.js",
-        "server/**/*.js"
+        "server/**/*.js",
+        "tests/dummy/config/**/*.js"
       ],
       excludedFiles: [
         "addon/**",
@@ -40,8 +40,7 @@ module.exports = {
         "tests/dummy/app/**"
       ],
       parserOptions: {
-        sourceType: "script",
-        ecmaVersion: 2015
+        sourceType: "script"
       },
       env: {
         browser: false,
@@ -53,6 +52,10 @@ module.exports = {
         require("eslint-plugin-node").configs.recommended.rules,
         {
           // add your custom rules and overrides for node files here
+
+          // this can be removed once the following is fixed
+          // https://github.com/mysticatea/eslint-plugin-node/issues/77
+          "node/no-unpublished-require": "off"
         }
       )
     }


### PR DESCRIPTION
This can be removed once the following is fixed
https://github.com/mysticatea/eslint-plugin-node/issues/77

It also fix the ecmaVersion version to the good one