### PR TITLE
Disable camelcase rule for testem.js file

### DIFF
--- a/ember.js
+++ b/ember.js
@@ -19,6 +19,12 @@ module.exports = {
     "./core.js"
   ],
   overrides: [
+    {
+      files: ["testem.js"],
+      rules: {
+        camelcase: 0
+      }
+    },
     // node files
     {
       files: [


### PR DESCRIPTION
Testem configuration is using camelcase everywhere... so this little changes is here to disable camelcase rules for testem.js file.
