### PR TITLE
feat: allow decorators

### DIFF
--- a/ember.js
+++ b/ember.js
@@ -7,9 +7,13 @@ module.exports = {
     server: true, // mirage
     withFeature: true // feature flag
   },
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: "module"
+    sourceType: "module",
+    ecmaFeatures: {
+      legacyDecorators: true
+    }
   },
   plugins: ["ember"],
   extends: [


### PR DESCRIPTION
This small change allows to parse correctly the symbol `@` for [decorators](https://emberjs.github.io/rfcs/0408-decorators.html).

I thought it would be useful to enable it as more and more of ours apps/add-ons run with Ember 3.12.

I took inspiration from the ESLint configuration used when creating a new app with Ember 3.14 :
https://github.com/ember-cli/ember-new-output/blob/v3.14.0/.eslintrc.js

---

Edit:
So far [decorators are at Stage 2](https://github.com/tc39/proposal-decorators).
And ESLint ["only officially supports the latest final ECMAScript standard"](https://github.com/eslint/eslint#what-about-experimental-features) :
> ESLint's parser only officially supports the latest final ECMAScript standard. We will make changes to core rules in order to avoid crashes on stage 3 ECMAScript syntax proposals (as long as they are implemented using the correct experimental ESTree syntax). We may make changes to core rules to better work with language extensions (such as JSX, Flow, and TypeScript) on a case-by-case basis.

To make this work on your project, you will have to install `babel-eslint` as a `devDependency`, like in [Ember 3.14](https://github.com/ember-cli/ember-new-output/blob/v3.14.0/package.json).