### PR TITLE
fix: add ember-recommended in every ember configs

### DIFF
--- a/ember-addon.js
+++ b/ember-addon.js
@@ -13,6 +13,7 @@ module.exports = {
   plugins: ["ember", "ember-suave"],
   extends: [
     "eslint:recommended",
+    "plugin:ember/recommended",
     "plugin:ember-suave/recommended",
     "./core.js"
   ],

--- a/ember.js
+++ b/ember.js
@@ -13,6 +13,7 @@ module.exports = {
   plugins: ["ember", "ember-suave"],
   extends: [
     "eslint:recommended",
+    "plugin:ember/recommended",
     "plugin:ember-suave/recommended",
     "./core.js"
   ],


### PR DESCRIPTION
Fix #50 

---

## Fix

### Add missing ember-recommanded configuration in ember.js and ember-test

It re-adds ursefull rules likes:
- ember/no-arrow-function-computed-properties
- ember/require-return-from-computed
- ember/avoid-leaking-state-in-ember-objects
- ...
