### PR TITLE
Refactor: Do not force empty lines between single line class members

### DIFF
--- a/core.js
+++ b/core.js
@@ -18,6 +18,13 @@ module.exports = {
     "prefer-destructuring": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
-    semi: ["error", "never"]
+    semi: ["error", "never"],
+    "lines-between-class-members": [
+      "error",
+      "always",
+      {
+        exceptAfterSingleLine: true
+      }
+    ]
   }
 }


### PR DESCRIPTION
A small patch to fix annoying lint errors due to the config of the rule [lines-between-class-members](https://eslint.org/docs/rules/lines-between-class-members).
With the current config of this rule, we are not allowed to write something like this:

```javascript
class Foo {
  bar = true
  fizz = false
  buzz = true
}
```

Instead, we have to write this:

```javascript
class Foo {
  bar = true

  fizz = false

  buzz = true
}
```

Which is a little bit annoying.

This PR update the config for this rule to don't force an empty line between class members that are in one single line.

Example: 

```javascript
class Foo {
  bar = true
  fizz = false
  buzz = true // new line is not mandatory here

  toString() { // New line is mandatory here
    return `bar: ${this.bar}, fizz: ${this.fizz}, buzz: ${this.buzz}`
  }
}
```