### PR TITLE
fix: fix exposed files defined in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "prettier": "^2.3.0"
   },
   "files": [
+    "core.js",
     "ember-addon.js",
+    "ember-core.js",
     "ember.js",
     "es5.js",
     "index.js",


### PR DESCRIPTION
## Fix

-fix exposed files defined in the package.json #81

core.js and ember-core.js are needed in order to be extended  by the others configuration.