### PR TITLE
fix(ember-addon): detect blueprints in subfolders

### DIFF
--- a/ember-addon.js
+++ b/ember-addon.js
@@ -10,7 +10,7 @@ module.exports = {
         "./ember-cli-build.js",
         "./index.js",
         "./testem.js",
-        "./blueprints/*/index.js",
+        "./blueprints/**/index.js",
         "./config/**/*.js",
         "./tests/dummy/config/**/*.js"
       ],


### PR DESCRIPTION
## FIx

-  ember-addon: detect blueprints in subfolders (#82)