### PR TITLE
Relax prefer-destructuring  rule

### DIFF
--- a/core.js
+++ b/core.js
@@ -15,7 +15,16 @@ module.exports = {
     "no-var": "error",
     "no-useless-rename": "error",
     "object-shorthand": ["error", "always"],
-    "prefer-destructuring": "error",
+    "prefer-destructuring": ["error", {
+      "VariableDeclarator": {
+        "array": true,
+        "object": true
+      },
+      "AssignmentExpression": {
+        "array": false,
+        "object": false
+      }
+    }],
     "prefer-spread": "error",
     "prefer-template": "error",
     semi: ["error", "never"],


### PR DESCRIPTION
Currently, `prefer-destructuring` is always enforced.

```js
// Incorrect
let foo = obj.foo
let bar = obj.foo
bar = obj.foo

// Correct
let { foo } = obj
let { foo: bar } = obj
;({ foo: bar } = obj)
```

The last correct line is neither nice nor easy to read. This PR proposes relaxing the rule for assignments, leaving it on for declarations only:

```js
// Incorrect
let foo = obj.foo
let bar = obj.foo

// Correct
let { foo } = obj
let { foo: bar } = obj
bar = obj.foo
```