### PR TITLE
Release v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-peopledoc",
   "description": "JavaScript linting rules used at PeopleDoc",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "license": "MIT",
   "author": {
     "name": "PeopleDoc",


### PR DESCRIPTION
## Breaking

### Add compatibility with ESLint 8 (#118)

#### Use `@babel/eslint-parser` instead of archived `babel-eslint` repo for Ember projects

⚠️ If your project use Ember, you need to
- remove `babel-eslint` from your dependencies
- run `yarn add eslint @babel/core @babel/eslint-parser @babel/plugin-proposal-decorators -D`

Please check your `.eslintrc.js` file, it should start like this
```
module.exports = {
  root: true,

  plugins: ['ember'],
  extends: ['peopledoc/ember' /*, ... */], // or `peopledoc/ember-addon` in case you are in an addon
  
  ...
```

#### Replace [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node) by [eslint-plugin-n](https://github.com/weiran-zsd/eslint-plugin-node)

- `eslint-plugin-node` was not maintained
- ⚠️ if you use `plugins: ["node"],` plugin in your ESLint config (like `.eslintrc.js`) you have to replace it by `plugins: ["n"],`
  - same if you had some rules like `node/some-rule`, they become `n/some-rule` 

### Remove [eslint-plugin-ember-suave](https://github.com/DockYard/eslint-plugin-ember-suave) rules (#118)

It was added some years ago but it is not relevant anymore, repo is not really maintained and we can stick with `ember/recommended` rules for Ember projects

⚠️ if you have some `eslint-disable ember-suave/` in your project you will have to remove them

## CI

### New workflow to auto-update list of contributors (#94)

### Reuse organisation's workflow to run tag & publish (#92)

## Chore

### Refine information in `package.json` (#93)

### Relax prefer-destructuring rule (#89)

## Build

### Update [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) to 10.5.7 (#118)

Needed for ESLint 8 compatibility

### Upgrade [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) to 4.0.0 (#85 )

Drops support for 
- Node < 12 (this repo already only compatible with Node >= 12)
- Versions 5 and 6 of [eslint](https://github.com/eslint/eslint) (as far as i know we use 7+ on all / most of our projects)
- [prettier](https://github.com/prettier/prettier) <2.0 (we already have prettier 2.0 in dependencies)

### Upgrade  [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) from 10.6.0 to 10.6.1 (#119)

### Upgrade [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) from 10.5.9 to 10.6.0 (#116)

### Upgrade [prettier](https://github.com/prettier/prettier) from 2.6.1 to 2.6.2 (#115)

### Upgrade [prettier](https://github.com/prettier/prettier) from 2.6.0 to 2.6.1 (#113)

### Upgrade [minimist](https://github.com/substack/minimist) from 1.2.5 to 1.2.6 (#114)

### Upgrade [prettier](https://github.com/prettier/prettier) from 2.5.1 to 2.6.0 (#112)

### Upgrade [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) from 8.4.0 to 8.5.0 (#109)

### Upgrade [prettier](https://github.com/prettier/prettier) from 2.4.1 to 2.5.1 (#100)

### Upgrade [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) from 8.3.0 to 8.4.0 (#104)

### Upgrade [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) from 10.5.8 to 10.5.9 (#102)

### Upgrade [eslint-plugin-qunit](https://github.com/platinumazure/eslint-plugin-qunit) from 7.0.0 to 7.2.0 (#101)

### Upgrade [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) from 10.5.7 to 10.5.8 (#98)

### Upgrade [eslint-plugin-qunit](https://github.com/platinumazure/eslint-plugin-qunit) from 6.2.0 to 7.0.0 (#91)

### Update [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) from 10.5.5 to 10.5.7 (#90)

### Update [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) from 10.5.4 to 10.5.5 (#88)

### Update [prettier](https://github.com/prettier/prettier) from 2.4.0 to 2.4.1 (#87)

### Update [prettier](https://github.com/prettier/prettier) from 2.3.2 to 2.4.0 (#86)

### Update [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember) from 10.5.3 to 10.5.4 (#84)